### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.0.1
+## v1.1.1
+
+* Ficed CI errors. Switching to unittest because unittest2 is no longer compatible with python 3.10+
+
+## v1.1.0
 
 * Fix `ssl_verify` config was not respected for all requests in `st2service_handler`. #9
   

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - nagios
   - monitoring
   - alerting
-version : 1.1.0
+version : 1.1.1
 author : StackStorm, Inc.
 email : info@stackstorm.com
 python_versions:

--- a/tests/test_nagios_handler.py
+++ b/tests/test_nagios_handler.py
@@ -3,7 +3,7 @@ import json
 import mock
 import requests
 import responses
-import unittest2
+import unittest
 
 import st2service_handler as nagios_handler
 
@@ -27,7 +27,7 @@ class FakeResponse(object):
         raise Exception(self.reason)
 
 
-class NagiosHandlerTestCase(unittest2.TestCase):
+class NagiosHandlerTestCase(unittest.TestCase):
 
     def test_st2_headers_token_auth(self):
         nagios_handler.IS_API_KEY_AUTH = False


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- `unittest2` still relies on a `collections.MutableMapping` attribute that was moved to `collections.abc` in python 3.10